### PR TITLE
V1 alpha1- Review the VersionServiceImpl and Unit testing. #38

### DIFF
--- a/src/main/java/org/exoplatform/social/client/api/SocialClientContext.java
+++ b/src/main/java/org/exoplatform/social/client/api/SocialClientContext.java
@@ -196,7 +196,7 @@ public class SocialClientContext {
   private static int port = 8080;
   private static String protocol = "http";
   private static String portalContainerName;
-  private static String restContextName;
+  private static String restContextName = "rest-socialdemo";
   private static String restVersion = "v1-alpha1";
   private static String username;
   private static String password;

--- a/src/main/java/org/exoplatform/social/client/api/SocialClientContext.java
+++ b/src/main/java/org/exoplatform/social/client/api/SocialClientContext.java
@@ -197,7 +197,7 @@ public class SocialClientContext {
   private static String protocol = "http";
   private static String portalContainerName;
   private static String restContextName;
-  private static String restVersion;
+  private static String restVersion = "v1-alpha1";
   private static String username;
   private static String password;
   

--- a/src/main/java/org/exoplatform/social/client/api/net/SocialHttpClient.java
+++ b/src/main/java/org/exoplatform/social/client/api/net/SocialHttpClient.java
@@ -25,5 +25,14 @@ import org.apache.http.client.HttpClient;
  * Jun 29, 2011  
  */
 public interface SocialHttpClient extends HttpClient {
-
+  
+  public enum POLICY {
+    NO_AUTH,
+    BASIC_AUTH
+  }
+  /**
+   * Setting the basic authenticate which uses 
+   * the username/password in <code>SocialClientContext</code>
+   */
+  public void setBasicAuthenticateToRequest();
 }

--- a/src/main/java/org/exoplatform/social/client/api/net/SocialHttpClientException.java
+++ b/src/main/java/org/exoplatform/social/client/api/net/SocialHttpClientException.java
@@ -14,36 +14,34 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.exoplatform.social.client.core.net;
-
-import org.exoplatform.social.client.api.SocialClientContext;
-import org.junit.After;
-import org.junit.Before;
+package org.exoplatform.social.client.api.net;
 
 /**
  * Created by The eXo Platform SAS
  * Author : eXoPlatform
  *          exo@exoplatform.com
- * Jun 29, 2011  
+ * Jun 30, 2011  
  */
-public abstract class AbstractClientTest {
+@SuppressWarnings("serial")
+public class SocialHttpClientException extends RuntimeException {
 
-  @Before
-  public void setUp() throws Exception {
-    SocialClientContext.setHost("192.168.1.94");
-    SocialClientContext.setPort(8080);
-    SocialClientContext.setUsername("demo");
-    SocialClientContext.setPassword("gtn");
-    SocialClientContext.setProtocol("http");
+
+  /**
+   * Constructor for SocialHttpClientException.
+   *
+   * @param message      the message of exception
+   * @param cause        the cause of exception
+   */
+  public SocialHttpClientException(String message, Throwable cause) {
+    super(message, cause);
   }
   
-  @After
-  public void tearDown() throws Exception {
-
-    SocialClientContext.setHost(null);
-    SocialClientContext.setPort(0);
-    SocialClientContext.setUsername(null);
-    SocialClientContext.setPassword(null);
-    SocialClientContext.setProtocol(null);
+  /**
+   * Constructor for SocialHttpClientException.
+   * @param message the message of exception
+   */
+  public SocialHttpClientException(String message) {
+    super(message, null);
   }
+  
 }

--- a/src/main/java/org/exoplatform/social/client/core/net/SocialHttpClientImpl.java
+++ b/src/main/java/org/exoplatform/social/client/core/net/SocialHttpClientImpl.java
@@ -38,6 +38,7 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.BasicHttpProcessor;
 import org.apache.http.protocol.HttpContext;
 import org.exoplatform.social.client.api.SocialClientContext;
 import org.exoplatform.social.client.api.net.SocialHttpClient;
@@ -86,13 +87,13 @@ public final class SocialHttpClientImpl implements SocialHttpClient {
     //delegate = new DefaultHttpClient(ccm, params);
     
     delegate = new DefaultHttpClient(ccm, params) {
-      /*
+      
       @Override
       protected BasicHttpProcessor createHttpProcessor() {
           // Add interceptor to prevent making requests from main thread.
           BasicHttpProcessor processor = super.createHttpProcessor();
           return processor;
-      }*/
+      }
       
       @Override
       protected HttpContext createHttpContext() {
@@ -106,8 +107,7 @@ public final class SocialHttpClientImpl implements SocialHttpClient {
       }
     };
     
-    delegate.getCredentialsProvider().setCredentials(new AuthScope(SocialClientContext.getHost(), SocialClientContext.getPort()), 
-                                            new UsernamePasswordCredentials(SocialClientContext.getUsername(), SocialClientContext.getPassword()));
+    
     
   }
   
@@ -175,6 +175,13 @@ public final class SocialHttpClientImpl implements SocialHttpClient {
     return delegate.execute(target, request, responseHandler, context);
   }
   
+  @Override
+  public void setBasicAuthenticateToRequest() {
+    if (delegate == null) return;
+    delegate.getCredentialsProvider().setCredentials(new AuthScope(SocialClientContext.getHost(), SocialClientContext.getPort()), 
+                                                     new UsernamePasswordCredentials(SocialClientContext.getUsername(), SocialClientContext.getPassword()));
+    
+  }
   
 
 }

--- a/src/main/java/org/exoplatform/social/client/core/service/VersionServiceImpl.java
+++ b/src/main/java/org/exoplatform/social/client/core/service/VersionServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.http.HttpResponse;
+import org.exoplatform.social.client.api.SocialClientContext;
 import org.exoplatform.social.client.api.net.SocialHttpClient.POLICY;
 import org.exoplatform.social.client.api.service.VersionService;
 import org.exoplatform.social.client.core.util.SocialHttpClientSupport;
@@ -39,7 +40,7 @@ public class VersionServiceImpl implements VersionService {
   private final static String SUPPORTED_FIELD = "versions";
   @Override
   public String getLatest() {
-    final String targetURL = "/rest-socialdemo/api/social/version/latest.json";
+    final String targetURL = "/" + SocialClientContext.getRestContextName() + "/api/social/version/latest.json";
     HttpResponse response = SocialHttpClientSupport.executeGet(targetURL, POLICY.NO_AUTH);
     String content = SocialHttpClientSupport.getContent(response);
     try {
@@ -52,7 +53,7 @@ public class VersionServiceImpl implements VersionService {
 
   @Override
   public String[] getSupported() {
-    final String targetURL = "/rest-socialdemo/api/social/version/supported.json";
+    final String targetURL = "/" + SocialClientContext.getRestContextName() + "/api/social/version/supported.json";
 
     HttpResponse response = SocialHttpClientSupport.executeGet(targetURL, POLICY.NO_AUTH);
     String content = SocialHttpClientSupport.getContent(response);

--- a/src/main/java/org/exoplatform/social/client/core/service/VersionServiceImpl.java
+++ b/src/main/java/org/exoplatform/social/client/core/service/VersionServiceImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2003-2011 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.social.client.core.service;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.HttpResponse;
+import org.exoplatform.social.client.api.net.SocialHttpClient.POLICY;
+import org.exoplatform.social.client.api.service.VersionService;
+import org.exoplatform.social.client.core.util.SocialHttpClientSupport;
+import org.exoplatform.social.client.core.util.SocialJSONDecodingSupport;
+import org.json.simple.parser.ParseException;
+
+/**
+ * Created by The eXo Platform SAS
+ * Author : eXoPlatform
+ *          exo@exoplatform.com
+ * Jun 30, 2011  
+ */
+public class VersionServiceImpl implements VersionService {
+
+  private final static String VERSION_FIELD = "version";
+  private final static String SUPPORTED_FIELD = "versions";
+  @Override
+  public String getLatest() {
+    final String targetURL = "/rest-socialdemo/api/social/version/latest.json";
+    HttpResponse response = SocialHttpClientSupport.executeGet(targetURL, POLICY.NO_AUTH);
+    String content = SocialHttpClientSupport.getContent(response);
+    try {
+      Map versionMap = SocialJSONDecodingSupport.parser(content);
+      return (String) versionMap.get(VERSION_FIELD);
+    } catch (ParseException pex) {
+      return "";
+    }
+  }
+
+  @Override
+  public String[] getSupported() {
+    final String targetURL = "/rest-socialdemo/api/social/version/supported.json";
+
+    HttpResponse response = SocialHttpClientSupport.executeGet(targetURL, POLICY.NO_AUTH);
+    String content = SocialHttpClientSupport.getContent(response);
+    try {
+      Map versionMap = SocialJSONDecodingSupport.parser(content);
+      List supportVersion = (LinkedList) versionMap.get(SUPPORTED_FIELD);
+      return (String[]) supportVersion.toArray(new String[0]);
+    } catch (ParseException pex) {
+      return null;
+    }
+  }
+
+  
+}

--- a/src/main/java/org/exoplatform/social/client/core/util/SocialHttpClientSupport.java
+++ b/src/main/java/org/exoplatform/social/client/core/util/SocialHttpClientSupport.java
@@ -34,7 +34,6 @@ import org.exoplatform.social.client.api.SocialClientContext;
 import org.exoplatform.social.client.api.net.SocialHttpClient;
 import org.exoplatform.social.client.api.net.SocialHttpClient.POLICY;
 import org.exoplatform.social.client.api.net.SocialHttpClientException;
-import org.exoplatform.social.client.core.net.DumpHttpResponse;
 import org.exoplatform.social.client.core.net.SocialHttpClientImpl;
 
 /**
@@ -85,9 +84,12 @@ public class SocialHttpClientSupport {
     HttpHost targetHost = new HttpHost(SocialClientContext.getHost(), SocialClientContext.getPort(), SocialClientContext.getProtocol()); 
     HttpClient httpClient = SocialHttpClientImpl.newInstance();
 
+    
     HttpPost httpPost = new HttpPost(targetURL);
     Header header = new BasicHeader("Content-Type", "application/json");
     httpPost.setHeader(header);
+    
+    
     try {
       return httpClient.execute(targetHost, httpPost);
     } catch (ClientProtocolException cpex) {
@@ -132,7 +134,6 @@ public class SocialHttpClientSupport {
     if (response == null)
       throw new NullPointerException("HttpResponse argument is not NULL.");
     HttpEntity entity = processContent(response);
-    DumpHttpResponse.dumpContent(entity);
     String content = null;
     try {
       if (entity.getContentLength() != -1) {

--- a/src/main/java/org/exoplatform/social/client/core/util/SocialJSONDecodingSupport.java
+++ b/src/main/java/org/exoplatform/social/client/core/util/SocialJSONDecodingSupport.java
@@ -16,8 +16,10 @@
  */
 package org.exoplatform.social.client.core.util;
 
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import org.exoplatform.social.client.api.model.Model;
 import org.json.simple.parser.ContainerFactory;
@@ -58,5 +60,25 @@ public class SocialJSONDecodingSupport {
       }
     };
     return (T) parser.parse(jsonContent, containerFactory);
+  }
+  
+  /**
+   * Parse JSON text into java Map object from the input source.
+   *  
+   * @param jsonContent Json content which you need to create the Model
+   * @throws ParseException Throw this exception if any
+   */
+  public static Map parser(String jsonContent) throws ParseException {
+    JSONParser parser = new JSONParser();
+    ContainerFactory containerFactory = new ContainerFactory() {
+      public List creatArrayContainer() {
+        return new LinkedList();
+      }
+
+      public Map createObjectContainer() {
+          return new LinkedHashMap();
+      }
+    };
+    return (Map) parser.parse(jsonContent, containerFactory);
   }
 }

--- a/src/test/java/org/exoplatform/social/client/core/net/DumpHttpResponse.java
+++ b/src/test/java/org/exoplatform/social/client/core/net/DumpHttpResponse.java
@@ -23,6 +23,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.ParseException;
 import org.apache.http.util.EntityUtils;
+import org.exoplatform.social.client.api.net.SocialHttpClientException;
 
 /**
  * Created by The eXo Platform SAS
@@ -38,10 +39,18 @@ public class DumpHttpResponse {
    * @throws ParseException
    * @throws IOException
    */
-  public static void dumpContent(HttpEntity entity) throws ParseException, IOException {
+  public static void dumpContent(HttpEntity entity) throws SocialHttpClientException {
     if (entity.getContentLength() != -1) {
-      String body = EntityUtils.toString(entity);
-      System.out.println("BODY::" + body);
+      String body;
+      try {
+        body = EntityUtils.toString(entity);
+        System.out.println("BODY::" + body);
+      } catch (ParseException pex) {
+        throw new SocialHttpClientException("dumpContent() is parsing error.", pex);
+      } catch (IOException ioex) {
+        throw new SocialHttpClientException("dumpContent() is IO error.", ioex);
+      }
+      
     }
   }
 

--- a/src/test/java/org/exoplatform/social/client/core/net/SocialHttpClientTest.java
+++ b/src/test/java/org/exoplatform/social/client/core/net/SocialHttpClientTest.java
@@ -21,7 +21,6 @@ import junit.framework.Assert;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
-import org.exoplatform.social.client.api.SocialClientContext;
 import org.exoplatform.social.client.api.net.SocialHttpClient.POLICY;
 import org.exoplatform.social.client.core.model.ActivityImpl;
 import org.exoplatform.social.client.core.util.SocialHttpClientSupport;

--- a/src/test/java/org/exoplatform/social/client/core/net/VersionHttpClientTest.java
+++ b/src/test/java/org/exoplatform/social/client/core/net/VersionHttpClientTest.java
@@ -16,6 +16,8 @@
  */
 package org.exoplatform.social.client.core.net;
 
+import java.util.Map;
+
 import junit.framework.Assert;
 
 import org.apache.http.HttpEntity;
@@ -23,7 +25,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
 import org.exoplatform.social.client.api.SocialClientContext;
 import org.exoplatform.social.client.api.net.SocialHttpClient.POLICY;
-import org.exoplatform.social.client.core.model.ActivityImpl;
 import org.exoplatform.social.client.core.util.SocialHttpClientSupport;
 import org.exoplatform.social.client.core.util.SocialJSONDecodingSupport;
 import org.junit.After;
@@ -34,36 +35,56 @@ import org.junit.Test;
  * Created by The eXo Platform SAS
  * Author : eXoPlatform
  *          exo@exoplatform.com
- * Jun 29, 2011  
+ * Jun 30, 2011  
  */
-public class SocialHttpClientTest extends AbstractClientTest {
+public class VersionHttpClientTest extends AbstractClientTest {
+
   @Before
   public void setUp() throws Exception {
     super.setUp();
-   
+    
   }
   
   @After
   public void tearDown() throws Exception {
     super.tearDown();
-    
   }
-   
+  
   @Test
-  public void testExecuteGetActivityWithHttpClient() throws Exception {
-    final String targetURL = "/rest-socialdemo/private/api/social/v1-alpha1/socialdemo/activity/d51715397f0001010077b5d08ddf12fc.json?poster_identity=1&number_of_comments=10&activity_stream=t";
-    HttpResponse response = SocialHttpClientSupport.executeGet(targetURL, POLICY.BASIC_AUTH);
+  public void testGetLatestVersion() throws Exception {
+    final String targetURL = "/rest-socialdemo/api/social/version/latest.json";
+    HttpResponse response = SocialHttpClientSupport.executeGet(targetURL, POLICY.NO_AUTH);
     Assert.assertNotNull("HttpResponse must not be NULL.", response);
     DumpHttpResponse.dumpHeader(response);
     HttpEntity entity = SocialHttpClientSupport.processContent(response);
     Assert.assertNotNull("HttpEntity must not be NULL.", entity);
     DumpHttpResponse.dumpContent(entity);
-    
     if (entity.getContentLength() != -1) {
       String body = EntityUtils.toString(entity);
-      ActivityImpl model = SocialJSONDecodingSupport.parser(ActivityImpl.class, body);
-      Assert.assertTrue(model.getId().length() > 0);
+      Map versionMap = SocialJSONDecodingSupport.parser(body);
+      Assert.assertEquals("Verifying the version of rest service.", SocialClientContext.getRestVersion(), versionMap.get("version"));
     }
+    
+    SocialHttpClientSupport.consume(entity);
+  }
+  
+  @Test
+  public void testGetSupportedVersion() throws Exception {
+    final String targetURL = "/rest-socialdemo/api/social/version/supported.json";
+    HttpResponse response = SocialHttpClientSupport.executeGet(targetURL, POLICY.NO_AUTH);
+    Assert.assertNotNull("HttpResponse must not be NULL.", response);
+    DumpHttpResponse.dumpHeader(response);
+    HttpEntity entity = SocialHttpClientSupport.processContent(response);
+    Assert.assertNotNull("HttpEntity must not be NULL.", entity);
+    DumpHttpResponse.dumpContent(entity);
+    if (entity.getContentLength() != -1) {
+      String body = EntityUtils.toString(entity);
+      Map versionMap = SocialJSONDecodingSupport.parser(body);
+      String supportedVersion = (String) versionMap.get("version");
+      String[] versions = supportedVersion.split(",");
+      Assert.assertTrue("Verifying the version of rest service.", versions.length > 0);
+    }
+    
     SocialHttpClientSupport.consume(entity);
   }
 }

--- a/src/test/java/org/exoplatform/social/client/core/service/VersionServiceImplTest.java
+++ b/src/test/java/org/exoplatform/social/client/core/service/VersionServiceImplTest.java
@@ -14,36 +14,49 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.exoplatform.social.client.core.net;
+package org.exoplatform.social.client.core.service;
+
+import junit.framework.Assert;
 
 import org.exoplatform.social.client.api.SocialClientContext;
+import org.exoplatform.social.client.api.service.VersionService;
+import org.exoplatform.social.client.core.net.AbstractClientTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Created by The eXo Platform SAS
  * Author : eXoPlatform
  *          exo@exoplatform.com
- * Jun 29, 2011  
+ * Jun 30, 2011  
  */
-public abstract class AbstractClientTest {
+public class VersionServiceImplTest extends AbstractClientTest {
 
+  private VersionService service = null;
   @Before
   public void setUp() throws Exception {
-    SocialClientContext.setHost("192.168.1.94");
-    SocialClientContext.setPort(8080);
-    SocialClientContext.setUsername("demo");
-    SocialClientContext.setPassword("gtn");
-    SocialClientContext.setProtocol("http");
+    super.setUp();
+    service = new VersionServiceImpl();
   }
   
   @After
   public void tearDown() throws Exception {
-
-    SocialClientContext.setHost(null);
-    SocialClientContext.setPort(0);
-    SocialClientContext.setUsername(null);
-    SocialClientContext.setPassword(null);
-    SocialClientContext.setProtocol(null);
+    super.tearDown();
+    service = null;
   }
+   
+  @Test
+  public void testGetLatestVersion() throws Exception {
+    String version = service.getLatest();
+    Assert.assertEquals("Verifying rest service version.", SocialClientContext.getRestVersion(), version);
+  }
+  
+  @Test
+  public void testGetSupportedVersion() throws Exception {
+    String[] versions = service.getSupported();
+    Assert.assertTrue("Rest Service version support greater than zero.", versions.length > 0);
+    Assert.assertEquals("Verifying rest service version.", SocialClientContext.getRestVersion(), versions[0]);
+  }
+  
 }

--- a/src/test/java/org/exoplatform/social/client/core/util/SocialJSONDecodingSupportTest.java
+++ b/src/test/java/org/exoplatform/social/client/core/util/SocialJSONDecodingSupportTest.java
@@ -14,36 +14,46 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.exoplatform.social.client.core.net;
+package org.exoplatform.social.client.core.util;
 
-import org.exoplatform.social.client.api.SocialClientContext;
+import java.util.Map;
+
+import junit.framework.Assert;
+
+import org.exoplatform.social.client.core.model.ActivityImpl;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Created by The eXo Platform SAS
  * Author : eXoPlatform
  *          exo@exoplatform.com
- * Jun 29, 2011  
+ * Jun 30, 2011  
  */
-public abstract class AbstractClientTest {
+public class SocialJSONDecodingSupportTest {
 
   @Before
   public void setUp() throws Exception {
-    SocialClientContext.setHost("192.168.1.94");
-    SocialClientContext.setPort(8080);
-    SocialClientContext.setUsername("demo");
-    SocialClientContext.setPassword("gtn");
-    SocialClientContext.setProtocol("http");
+    
   }
   
   @After
   public void tearDown() throws Exception {
-
-    SocialClientContext.setHost(null);
-    SocialClientContext.setPort(0);
-    SocialClientContext.setUsername(null);
-    SocialClientContext.setPassword(null);
-    SocialClientContext.setProtocol(null);
+    
+  }
+  
+  @Test
+  public void testJSONParserWithClassType() throws Exception {
+    String jsonActivity = "{\"numberOfComments\":1,\"identityId\":\"d5039b437f0001010011fd153a4fcbd8\",\"liked\":true,}";
+    ActivityImpl model = SocialJSONDecodingSupport.parser(ActivityImpl.class, jsonActivity);
+    Assert.assertEquals("d5039b437f0001010011fd153a4fcbd8", model.getIdentityId());
+  }
+  
+  @Test
+  public void testJSONParser() throws Exception {
+    String jsonActivity = "{\"numberOfComments\":1,\"identityId\":\"d5039b437f0001010011fd153a4fcbd8\",\"liked\":true,}";
+    Map modelMap = SocialJSONDecodingSupport.parser(jsonActivity);
+    Assert.assertEquals("d5039b437f0001010011fd153a4fcbd8", modelMap.get("identityId"));
   }
 }


### PR DESCRIPTION
- Review the VersionServiceImpl and Unit testing.
- Include NO_AUTH, BASIC_AUTH when making request.
  Detail in SocialHttpClient.POLICY enum.

How to use the authentication to make request?
1. Using the org.exoplatform.social.client.core.util.SocialHttpClientSupport class
eg:  SocialHttpClientSupport.executeGet(targetURL, POLICY.BASIC_AUTH);
2. Not use the Authentication:
eg: SocialHttpClientSupport.executeGet(targetURL, POLICY.NO_AUTH);
